### PR TITLE
Add Swift package scaffolding with Csound backend

### DIFF
--- a/Artifacts/README.md
+++ b/Artifacts/README.md
@@ -1,0 +1,16 @@
+# Csound.xcframework Placeholder
+
+This directory is intentionally empty so that the repository can be opened on
+platforms where the prebuilt `Csound.xcframework` artifact is not available.
+
+To build the real Swift package on Apple platforms you must provide a
+prebuilt `Csound.xcframework` that bundles the Csound static libraries and
+public headers. Follow the instructions in the root `README.md` to produce the
+framework, then place it at:
+
+```
+Artifacts/Csound.xcframework
+```
+
+The Swift Package manifest automatically links the binary target when the
+package is resolved on Apple platforms.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let packageName = "FountainCoachSwiftCsound"
+
+var targets: [Target] = [
+    .target(
+        name: "SPManager",
+        dependencies: [],
+        swiftSettings: [
+            .unsafeFlags(["-enable-actor-data-race-checks"], .when(configuration: .debug))
+        ]
+    ),
+    .testTarget(
+        name: "SPManagerTests",
+        dependencies: ["SPManager"]
+    )
+]
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+let csoundDependencies: [Target.Dependency] = ["SPManager", "Csound"]
+targets.append(
+    .binaryTarget(
+        name: "Csound",
+        path: "Artifacts/Csound.xcframework"
+    )
+)
+#else
+let csoundDependencies: [Target.Dependency] = ["SPManager"]
+#endif
+
+targets.append(
+    .target(
+        name: "SPCsoundBackend",
+        dependencies: csoundDependencies,
+        swiftSettings: [
+            .unsafeFlags(["-enable-actor-data-race-checks"], .when(configuration: .debug))
+        ]
+    )
+)
+
+let package = Package(
+    name: packageName,
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8)
+    ],
+    products: [
+        .library(name: "SPManager", targets: ["SPManager"]),
+        .library(name: "SPCsoundBackend", targets: ["SPCsoundBackend"])
+    ],
+    targets: targets
+)

--- a/Sources/SPCsoundBackend/CsoundBackend.swift
+++ b/Sources/SPCsoundBackend/CsoundBackend.swift
@@ -1,0 +1,119 @@
+#if canImport(Darwin)
+import Foundation
+import Dispatch
+import SPManager
+
+@_silgen_name("csoundCreate")
+private func csoundCreate(_ hostData: UnsafeMutableRawPointer?) -> OpaquePointer?
+
+@_silgen_name("csoundDestroy")
+private func csoundDestroy(_ handle: OpaquePointer?)
+
+@_silgen_name("csoundCompileOrc")
+private func csoundCompileOrc(_ handle: OpaquePointer?, _ orc: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("csoundReadScore")
+private func csoundReadScore(_ handle: OpaquePointer?, _ score: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("csoundStart")
+private func csoundStart(_ handle: OpaquePointer?) -> Int32
+
+@_silgen_name("csoundStop")
+private func csoundStop(_ handle: OpaquePointer?)
+
+@_silgen_name("csoundSetControlChannel")
+private func csoundSetControlChannel(_ handle: OpaquePointer?, _ name: UnsafePointer<CChar>?, _ value: Double) -> Int32
+
+/// Errors thrown by ``CsoundBackend``.
+public enum CsoundBackendError: Error {
+    case initializationFailed
+    case compilationFailed(String)
+    case startFailed(Int32)
+    case invalidState(String)
+}
+
+/// Concrete backend backed by a real Csound runtime.
+public final class CsoundBackend: NSObject, SPBackend, @unchecked Sendable {
+    private var handle: OpaquePointer?
+    private var isRunning = false
+    private let renderQueue = DispatchQueue(label: "fountaincoach.csound.render")
+
+    public override init() {
+        super.init()
+    }
+
+    public func prepare() async throws {
+        if handle != nil { return }
+        guard let instance = csoundCreate(nil) else {
+            throw CsoundBackendError.initializationFailed
+        }
+        handle = instance
+    }
+
+    public func compile(program: SPProgram) async throws {
+        guard let handle else {
+            throw CsoundBackendError.invalidState("Csound has not been prepared")
+        }
+
+        guard case let .csound(orc, sco) = program else {
+            throw CsoundBackendError.compilationFailed("Unsupported program type")
+        }
+
+        let orcResult = orc.withCString { csoundCompileOrc(handle, $0) }
+        guard orcResult == 0 else {
+            throw CsoundBackendError.compilationFailed("Orchestra compilation failed with code \(orcResult)")
+        }
+
+        let scoreResult = sco.withCString { csoundReadScore(handle, $0) }
+        guard scoreResult == 0 else {
+            throw CsoundBackendError.compilationFailed("Score compilation failed with code \(scoreResult)")
+        }
+    }
+
+    public func start() async throws {
+        guard let handle else {
+            throw CsoundBackendError.invalidState("Csound has not been prepared")
+        }
+        guard !isRunning else { return }
+
+        let result = csoundStart(handle)
+        guard result == 0 else {
+            throw CsoundBackendError.startFailed(result)
+        }
+        isRunning = true
+    }
+
+    public func stop() async throws {
+        guard let handle else { return }
+        if isRunning {
+            csoundStop(handle)
+            isRunning = false
+        }
+    }
+
+    public func setControl(_ name: String, value: Double) async throws {
+        guard let handle else {
+            throw CsoundBackendError.invalidState("Csound has not been prepared")
+        }
+
+        let status = name.withCString { channel -> Int32 in
+            csoundSetControlChannel(handle, channel, value)
+        }
+
+        guard status == 0 else {
+            throw CsoundBackendError.invalidState("Failed to set control \(name)")
+        }
+    }
+
+    public func teardown() async {
+        if let handle {
+            if isRunning {
+                csoundStop(handle)
+                isRunning = false
+            }
+            csoundDestroy(handle)
+            self.handle = nil
+        }
+    }
+}
+#endif

--- a/Sources/SPCsoundBackend/CsoundBackendUnavailable.swift
+++ b/Sources/SPCsoundBackend/CsoundBackendUnavailable.swift
@@ -1,0 +1,37 @@
+#if !canImport(Darwin)
+import Foundation
+import SPManager
+
+public enum CsoundBackendError: Error {
+    case unavailable
+}
+
+/// Placeholder backend for platforms where Csound is unavailable at build
+/// time. The methods throw immediately, instructing callers that the backend is
+/// not usable in the current environment.
+public final class CsoundBackend: SPBackend, @unchecked Sendable {
+    public init() {}
+
+    public func prepare() async throws {
+        throw CsoundBackendError.unavailable
+    }
+
+    public func compile(program: SPProgram) async throws {
+        throw CsoundBackendError.unavailable
+    }
+
+    public func start() async throws {
+        throw CsoundBackendError.unavailable
+    }
+
+    public func stop() async throws {
+        throw CsoundBackendError.unavailable
+    }
+
+    public func setControl(_ name: String, value: Double) async throws {
+        throw CsoundBackendError.unavailable
+    }
+
+    public func teardown() async {}
+}
+#endif

--- a/Sources/SPManager/SPBackend.swift
+++ b/Sources/SPManager/SPBackend.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Describes the life-cycle and control operations that a backend must
+/// implement to participate in the ``SPManager`` orchestration.
+///
+/// The protocol is class-constrained so that the manager can hold onto a single
+/// reference per session without copying state, while the ``Sendable``
+/// conformance is marked as unchecked because most audio engines are
+/// implemented with reference semantics.
+public protocol SPBackend: AnyObject {
+    /// Prepare any internal resources. This must be safe to call multiple
+    /// times and is expected to be allocation-heavy.
+    func prepare() async throws
+
+    /// Compile the supplied program into a runnable form.
+    func compile(program: SPProgram) async throws
+
+    /// Start rendering audio. Implementations must be idempotent and
+    /// allocation-free in the audio render path.
+    func start() async throws
+
+    /// Stop rendering audio. This should block until rendering has ceased.
+    func stop() async throws
+
+    /// Update a named control parameter to a scalar value.
+    func setControl(_ name: String, value: Double) async throws
+
+    /// Tear down the backend. Called when a session is removed from the manager
+    /// or replaced with a new backend.
+    func teardown() async
+}
+
+extension SPBackend {
+    public func prepare() async throws {}
+    public func compile(program: SPProgram) async throws {}
+    public func start() async throws {}
+    public func stop() async throws {}
+    public func setControl(_ name: String, value: Double) async throws {}
+    public func teardown() async {}
+}

--- a/Sources/SPManager/SPManager.swift
+++ b/Sources/SPManager/SPManager.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// High level orchestrator that keeps track of synthesizer sessions and their
+/// associated backends.
+public actor SPManager {
+    private struct SessionState {
+        var backend: SPBackend
+        var lastProgram: SPProgram?
+
+        init(backend: SPBackend) {
+            self.backend = backend
+        }
+    }
+
+    private var sessions: [SPSessionID: SessionState] = [:]
+
+    public init() {}
+
+    /// Register or replace the backend associated with a session identifier.
+    @discardableResult
+    public func upsertSession(id: SPSessionID, backend: SPBackend) async throws -> SPBackend {
+        if var state = sessions[id] {
+            await state.backend.teardown()
+            state.backend = backend
+            sessions[id] = state
+        } else {
+            sessions[id] = SessionState(backend: backend)
+        }
+
+        try await backend.prepare()
+        return backend
+    }
+
+    /// Remove a session entirely, shutting down its backend.
+    public func removeSession(id: SPSessionID) async {
+        if let state = sessions.removeValue(forKey: id) {
+            await state.backend.teardown()
+        }
+    }
+
+    /// Compile a program for a particular session.
+    public func compile(id: SPSessionID, program: SPProgram) async throws {
+        guard var state = sessions[id] else {
+            throw SPManagerError.sessionNotFound(id)
+        }
+
+        try await state.backend.compile(program: program)
+        state.lastProgram = program
+        sessions[id] = state
+    }
+
+    /// Start rendering audio for a session.
+    public func start(id: SPSessionID) async throws {
+        guard let state = sessions[id] else {
+            throw SPManagerError.sessionNotFound(id)
+        }
+        try await state.backend.start()
+    }
+
+    /// Stop rendering audio for a session.
+    public func stop(id: SPSessionID) async throws {
+        guard let state = sessions[id] else {
+            throw SPManagerError.sessionNotFound(id)
+        }
+        try await state.backend.stop()
+    }
+
+    /// Apply a control parameter update to the session backend.
+    public func setControl(id: SPSessionID, _ name: String, value: Double) async throws {
+        guard let state = sessions[id] else {
+            throw SPManagerError.sessionNotFound(id)
+        }
+        try await state.backend.setControl(name, value: value)
+    }
+
+    /// Retrieve the last compiled program for inspection.
+    public func lastProgram(id: SPSessionID) async -> SPProgram? {
+        sessions[id]?.lastProgram
+    }
+
+    /// Returns whether a session is currently registered.
+    public func hasSession(id: SPSessionID) async -> Bool {
+        sessions[id] != nil
+    }
+}

--- a/Sources/SPManager/SPMockBackend.swift
+++ b/Sources/SPManager/SPMockBackend.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Lightweight in-memory backend that records lifecycle invocations. Useful for
+/// previews and unit tests where a real audio engine is undesirable.
+public final class SPMockBackend: SPBackend, @unchecked Sendable {
+    public private(set) var preparedCount = 0
+    public private(set) var compiledPrograms: [SPProgram] = []
+    public private(set) var startedCount = 0
+    public private(set) var stoppedCount = 0
+    public private(set) var controlEvents: [(String, Double)] = []
+
+    public init() {}
+
+    public func prepare() async throws {
+        preparedCount += 1
+    }
+
+    public func compile(program: SPProgram) async throws {
+        compiledPrograms.append(program)
+    }
+
+    public func start() async throws {
+        startedCount += 1
+    }
+
+    public func stop() async throws {
+        stoppedCount += 1
+    }
+
+    public func setControl(_ name: String, value: Double) async throws {
+        controlEvents.append((name, value))
+    }
+
+    public func teardown() async {
+        compiledPrograms.removeAll(keepingCapacity: true)
+        controlEvents.removeAll(keepingCapacity: true)
+    }
+}

--- a/Sources/SPManager/SPTypes.swift
+++ b/Sources/SPManager/SPTypes.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A unique identifier representing a logical synthesizer session managed by
+/// ``SPManager``.
+public typealias SPSessionID = String
+
+/// Describes an audio program that can be compiled by an ``SPBackend``.
+public enum SPProgram: Equatable, Sendable {
+    /// A Csound program described by orchestra (`orc`) and score (`sco`)
+    /// source strings.
+    case csound(orc: String, sco: String)
+}
+
+/// Possible errors surfaced by ``SPManager`` while orchestrating backends.
+public enum SPManagerError: Error, Equatable {
+    case sessionAlreadyRegistered(SPSessionID)
+    case sessionNotFound(SPSessionID)
+    case backendUnavailable(String)
+    case invalidProgram(String)
+}

--- a/Tests/SPManagerTests/SPManagerTests.swift
+++ b/Tests/SPManagerTests/SPManagerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import SPManager
+
+final class SPManagerTests: XCTestCase {
+    func testSessionLifecycle() async throws {
+        let manager = SPManager()
+        let backend = SPMockBackend()
+        let session: SPSessionID = "main"
+
+        try await manager.upsertSession(id: session, backend: backend)
+        try await manager.compile(id: session, program: .csound(orc: "instr 1", sco: "i1 0 1"))
+        try await manager.start(id: session)
+        try await manager.setControl(id: session, "freq", value: 440)
+        try await manager.stop(id: session)
+
+        XCTAssertEqual(backend.preparedCount, 1)
+        XCTAssertEqual(backend.startedCount, 1)
+        XCTAssertEqual(backend.stoppedCount, 1)
+        XCTAssertEqual(backend.controlEvents.count, 1)
+
+        await manager.removeSession(id: session)
+        let stillRegistered = await manager.hasSession(id: session)
+        XCTAssertFalse(stillRegistered)
+        XCTAssertTrue(backend.controlEvents.isEmpty)
+    }
+
+    func testCompileWithoutSessionFails() async {
+        let manager = SPManager()
+        await XCTAssertThrowsErrorAsync(try await manager.compile(id: "missing", program: .csound(orc: "", sco: "")))
+    }
+}
+
+extension XCTestCase {
+    func XCTAssertThrowsErrorAsync<T>(_ expression: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async {
+        do {
+            _ = try await expression()
+            XCTFail(message(), file: file, line: line)
+        } catch {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create the Swift Package manifest with SPManager and SPCsoundBackend targets, wiring the binary Csound target for Apple platforms
- implement the SPManager API, in-memory mock backend, and a Csound-backed adapter that binds to the prebuilt xcframework
- document the Option A workflow and add unit tests covering the manager lifecycle

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68d37810f45483338eb5118e70bbb6fa