### PR TITLE
Add helper script for generating Csound xcframework

### DIFF
--- a/Artifacts/README.md
+++ b/Artifacts/README.md
@@ -1,16 +1,74 @@
-# Csound.xcframework Placeholder
+# Csound.xcframework Placeholder & Build Script
 
-This directory is intentionally empty so that the repository can be opened on
-platforms where the prebuilt `Csound.xcframework` artifact is not available.
+This directory holds the prebuilt `Csound.xcframework` that the Swift Package
+expects when it is resolved on Apple platforms. The repository itself does not
+ship the binary artifact; instead it provides documentation and a helper script
+for producing one from locally built Csound libraries.
 
-To build the real Swift package on Apple platforms you must provide a
-prebuilt `Csound.xcframework` that bundles the Csound static libraries and
-public headers. Follow the instructions in the root `README.md` to produce the
-framework, then place it at:
+## Quick Recap
+
+- Place the finished framework at `Artifacts/Csound.xcframework`.
+- Commit the framework **only** if you intend to distribute the binary under an
+  appropriate license.
+- When the framework is absent (default in this repository) SwiftPM continues to
+  work on non-Apple platforms thanks to the mock backend.
+
+## Building the Framework
+
+Use the `build_csound_xcframework.sh` helper to wrap your compiled Csound
+libraries into an xcframework. The script runs on macOS (because it uses
+`xcodebuild`) and expects you to provide per-architecture directories containing
+`libcsound.a` (or `libcsound.dylib`) plus the matching public headers.
 
 ```
-Artifacts/Csound.xcframework
+Artifacts/build_csound_xcframework.sh \
+    --ios-arm64     /path/to/csound/ios-arm64 \
+    --ios-simulator /path/to/csound/ios-sim-arm64 \
+    --macos-arm64   /path/to/csound/macos-arm64 \
+    --macos-x86_64  /path/to/csound/macos-x86_64 \
+    --zip
 ```
 
-The Swift Package manifest automatically links the binary target when the
-package is resolved on Apple platforms.
+Each supplied directory should look like:
+
+```
+macos-arm64/
+├─ libcsound.a
+└─ include/
+```
+
+The script will:
+
+1. Validate that every provided directory contains a library and headers.
+2. Invoke `xcodebuild -create-xcframework …` to produce
+   `Artifacts/Csound.xcframework` (or a custom `--output`).
+3. Optionally create a zipped archive and print its SwiftPM checksum when `--zip`
+   is specified.
+
+Refer to the root `README.md` for detailed build notes if you still need to
+compile Csound for the relevant architectures.
+
+## Verifying the Framework
+
+After generating the framework you can sanity check it by inspecting the
+embedded slices:
+
+```
+$ xcrun xcodebuild -showBuildSettings -project /dev/null # ensures Xcode CLI tools
+$ lipo -info Artifacts/Csound.xcframework/macos-arm64/libcsound.a
+```
+
+You can also drop the zipped artifact into another Swift package, compute its
+checksum, and declare it as a binary target for distribution.
+
+## Cleaning Up
+
+To reset the repository to its placeholder state simply remove the generated
+framework:
+
+```
+rm -rf Artifacts/Csound.xcframework*
+```
+
+The mock backend will continue to function on platforms where the binary is not
+available.

--- a/Artifacts/build_csound_xcframework.sh
+++ b/Artifacts/build_csound_xcframework.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: build_csound_xcframework.sh \
+           --ios-arm64 <DIR> \
+           --ios-simulator <DIR> \
+           --macos-arm64 <DIR> \
+           --macos-x86_64 <DIR> \
+           [--watchos-arm64 <DIR>] \
+           [--watchos-simulator <DIR>] \
+           [--tvos-arm64 <DIR>] \
+           [--tvos-simulator <DIR>] \
+           [--output <PATH>] \
+           [--zip]
+
+Each <DIR> must contain a compiled libcsound.a (or libcsound.dylib) and an
+include/ directory with the public headers for that slice. The script simply
+wraps the xcodebuild -create-xcframework command so that the resulting
+Csound.xcframework can be dropped into Artifacts/.
+
+Examples of directory layouts (absolute paths recommended):
+  ios-arm64/
+    ├─ libcsound.a
+    └─ include/
+  macos-arm64/
+    ├─ libcsound.a
+    └─ include/
+
+Set --zip to also produce Csound.xcframework.zip and print its SwiftPM
+checksum. When --output is omitted the framework is written to
+Artifacts/Csound.xcframework relative to this repository.
+USAGE
+}
+
+ensure_dir() {
+  local label="$1"
+  local dir="$2"
+  if [[ ! -d "$dir" ]]; then
+    echo "error: missing directory for $label: $dir" >&2
+    exit 1
+  fi
+  if [[ ! -f "$dir/libcsound.a" && ! -f "$dir/libcsound.dylib" ]]; then
+    echo "error: $label directory does not contain libcsound.a or libcsound.dylib" >&2
+    exit 1
+  fi
+  if [[ ! -d "$dir/include" ]]; then
+    echo "error: $label directory does not contain an include/ directory" >&2
+    exit 1
+  fi
+}
+
+ARGS=("$@")
+OUTPUT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/Artifacts/Csound.xcframework"
+ZIP=false
+LIB_ARGS=()
+
+declare -A LABELS=(
+  [--ios-arm64]="iOS arm64"
+  [--ios-simulator]="iOS Simulator"
+  [--macos-arm64]="macOS arm64"
+  [--macos-x86_64]="macOS x86_64"
+  [--watchos-arm64]="watchOS arm64"
+  [--watchos-simulator]="watchOS Simulator"
+  [--tvos-arm64]="tvOS arm64"
+  [--tvos-simulator]="tvOS Simulator"
+)
+
+if [[ ${#ARGS[@]} -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --zip)
+      ZIP=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --ios-arm64|--ios-simulator|--macos-arm64|--macos-x86_64|--watchos-arm64|--watchos-simulator|--tvos-arm64|--tvos-simulator)
+      if [[ $# -lt 2 ]]; then
+        echo "error: missing value for $1" >&2
+        exit 1
+      fi
+      FLAG="$1"
+      DIR="$2"
+      ensure_dir "${LABELS[$FLAG]}" "$DIR"
+      LIBNAME="libcsound.a"
+      if [[ ! -f "$DIR/$LIBNAME" ]]; then
+        LIBNAME="libcsound.dylib"
+      fi
+      LIB_ARGS+=("-library" "$DIR/$LIBNAME" "-headers" "$DIR/include")
+      shift 2
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ${#LIB_ARGS[@]} -eq 0 ]]; then
+  echo "error: no architectures provided" >&2
+  usage
+  exit 1
+fi
+
+FRAMEWORK_DIR="$(dirname "$OUTPUT")"
+mkdir -p "$FRAMEWORK_DIR"
+
+set -x
+xcodebuild -create-xcframework "${LIB_ARGS[@]}" -output "$OUTPUT"
+set +x
+
+echo "Created $OUTPUT"
+
+if $ZIP; then
+  ZIP_PATH="$OUTPUT.zip"
+  rm -f "$ZIP_PATH"
+  (cd "$(dirname "$OUTPUT")" && ditto -c -k "$(basename "$OUTPUT")" "$(basename "$ZIP_PATH")")
+  echo "Created $ZIP_PATH"
+  if command -v swift >/dev/null 2>&1; then
+    CHECKSUM=$(swift package compute-checksum "$ZIP_PATH")
+    echo "SwiftPM checksum: $CHECKSUM"
+  else
+    echo "swift executable not available; skipped checksum calculation"
+  fi
+fi


### PR DESCRIPTION
## Summary
- add a macOS helper script that wraps `xcodebuild -create-xcframework` for Csound builds
- expand the Artifacts README with detailed instructions for generating, verifying, and cleaning the framework placeholder

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68d37c3451548333b50b27f36f0c94ae